### PR TITLE
Work with Noir multipart/form-data requests.

### DIFF
--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -13,7 +13,8 @@
     (.encode (BASE64Encoder.) seed)))
 
 (defn- valid-request? [req]
-  (let [param-token  (get-in req [:form-params "__anti-forgery-token"])
+  (let [param-token  (or (get-in req [:multipart-params "__anti-forgery-token"])
+                         (get-in req [:form-params "__anti-forgery-token"]))
         cookie-token (get-in req [:cookies "__anti-forgery-token" :value])]
     (and param-token
          cookie-token


### PR DESCRIPTION
Fix up so we work with Noir, which puts multipart/form-data encoded request params in :multipart-params and leaves :form-params empty.  I need this so that my file upload forms work.
