### PR TITLE
Don't try to add a cookie to a nil response.

### DIFF
--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -40,4 +40,5 @@
     (binding [*anti-forgery-token* (generate-token)]
       (if (and (post-request? request) (not (valid-request? request)))
         (access-denied "<h1>Invalid anti-forgery token</h1>")
-        (assoc-token-cookie (handler request))))))
+        (if-let [response (handler request)]
+          (assoc-token-cookie response))))))

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -35,3 +35,8 @@
     (let [response ((wrap-anti-forgery handler) (request :get "/"))]
       (is (= (get-in response [:cookies "__anti-forgery-token"])
              (:body response))))))
+
+(deftest nil-response
+  (letfn [(handler [request] nil)]
+    (let [response ((wrap-anti-forgery handler) (request :get "/"))]
+      (is (nil? response)))))


### PR DESCRIPTION
When trying to use this with Noir, I discovered that wrap-anti-forgery was creating a response map even when the response from the underlying handler was nil.  I brought this up on the Noir list, and Chris Granger said to file a pull request here.  The thread on the Noir list is [here](https://groups.google.com/forum/?fromgroups#!topic/clj-noir/KMtNMu8F6vg).

I originally had a check in `assoc-token-cookie` for a nil response, but I moved it to `wrap-anti-forgery` to keep from unnecessarily generating a new token.  Especially since that could consume valuable entropy.

I also added a test for this scenario too.  Let me know if there's anything you need me to do!
