### PR TITLE
Reduce token size to avoid linefeeds in the data.

### DIFF
--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -8,7 +8,7 @@
   *anti-forgery-token*)
 
 (defn- generate-token []
-  (let [seed (byte-array 64)]
+  (let [seed (byte-array 32)]
     (.nextBytes (SecureRandom/getInstance "SHA1PRNG") seed)
     (.encode (BASE64Encoder.) seed)))
 

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -40,3 +40,12 @@
   (letfn [(handler [request] nil)]
     (let [response ((wrap-anti-forgery handler) (request :get "/"))]
       (is (nil? response)))))
+
+(deftest no-lf-in-token-test
+  (letfn [(handler [request]
+            {:status 200
+             :headers {}
+             :body *anti-forgery-token*})]
+    (let [response ((wrap-anti-forgery handler) (request :get "/"))
+          token    (get-in response [:cookies "__anti-forgery-token"])]
+      (is (not (.contains token "\n"))))))


### PR DESCRIPTION
32 bytes of random data is plenty, and keep us from the 57 byte
limit where BASE64Encoder will split the base 64 line and insert
a linefeed.  This was causing issues in Google Chrome as the linefeed
would get converted into a space and cause the comparison with the
hidden field to fail.

I opened a ticket for this (#7), but I figured it was best to put something
together and push it up.  I have an alternate implementation that uses
the same size token, but also introduces a dependency on
`clojure.data.codec.base64`.  In the end, I thought this was the best
solution since it avoids an extra dependency, and there's still enough
random data to prevent forged requests.
