### PR TITLE
anti-forgery-session storing up to limit tokens in session

### DIFF
--- a/src/ring/middleware/anti_forgery_session.clj
+++ b/src/ring/middleware/anti_forgery_session.clj
@@ -1,0 +1,68 @@
+(ns ring.middleware.anti-forgery-session
+  "Ring middleware to prevent CSRF attacks with up to limit anti-forgery tokens stored in the session."
+  (:import java.security.SecureRandom
+           sun.misc.BASE64Encoder))
+
+(def ^:constant ^{:doc "Name of the hidden field in POST forms that contains the anti-forgery-token."}
+  anti-forgery-token-name "__anti-forgery-token")
+
+(def ^:private ^:dynamic ^{:doc "Private binding that stores the anti-forgery token for the current request."}
+  *anti-forgery-token*)
+
+(defn- generate-token []
+  (let [seed (byte-array 32)]
+    (.nextBytes (SecureRandom/getInstance "SHA1PRNG") seed)
+    (.encode (BASE64Encoder.) seed)))
+
+(defn anti-forgery-token
+  "Returns the anti-forgery-token for the active request that
+   must be included in POST forms if the handler is wrapped in
+   wrap-anti-forgery-session."
+  []
+  (when-not @*anti-forgery-token*
+    (reset! *anti-forgery-token* (generate-token)))
+  @*anti-forgery-token*)
+
+(defn- form-params [req]
+  (merge (:form-params req)
+         (:multipart-params req)))
+
+(defn- valid-request? [req]
+  (let [param-token  (-> req form-params (get anti-forgery-token-name))
+        session-tokens (get-in req [:session anti-forgery-token-name])]
+    (and param-token (some #(= param-token %) session-tokens))))
+
+(defn- assoc-token-session [response request limit]
+  (let [session (when (contains? response :session) (:session response {}))
+        session (or session (:session request))
+        session (update-in session [anti-forgery-token-name]
+                           (fnil #(-> % (conj @*anti-forgery-token*) (subvec 1))
+                                (vec (repeat limit nil))))]
+    (assoc response :session session)))
+
+(defn- post-request? [request]
+  (= :post (:request-method request)))
+
+(defn- access-denied [body]
+  {:status 403
+   :headers {"Content-Type" "text/html"}
+   :body body})
+
+(defn wrap-anti-forgery-session
+  "Middleware that prevents CSRF attacks. Any POST request to this handler must
+  contain an anti-forgery-token-name parameter equal to one of the session's
+  anti-forgery tokens. If the token is missing or incorrect, an access-
+  denied response is returned.
+
+  Takes limit, the number of tokens to store in the session."
+  ([handler] (wrap-anti-forgery-session handler 1))
+  ([handler limit]
+      (fn [request]
+        (binding [*anti-forgery-token* (atom nil)]
+          (if (and (post-request? request) (not (valid-request? request)))
+            (access-denied "<h1>Invalid anti-forgery token</h1>")
+            (let [response (handler request)]
+              (if (and response @*anti-forgery-token*)
+                (assoc-token-session response request limit)
+                response)))))))
+

--- a/test/ring/middleware/test/anti_forgery_session.clj
+++ b/test/ring/middleware/test/anti_forgery_session.clj
@@ -1,0 +1,90 @@
+(ns ring.middleware.test.anti-forgery-session
+  (:use clojure.test)
+  (:use ring.middleware.anti-forgery-session
+        ring.mock.request))
+
+(deftest forgery-protection-test
+  (let [response {:status 200, :headers {}, :body "Foo"}
+        handler  (wrap-anti-forgery-session (constantly response))]
+    (are [status req] (= (:status (handler req)) status)
+      403 (request :post "/")
+      403 (-> (request :post "/")
+              (assoc :form-params {anti-forgery-token-name "foo"}))
+      403 (-> (request :post "/")
+              (assoc :session {anti-forgery-token-name ["foo"]})
+              (assoc :form-params {anti-forgery-token-name "bar"}))
+      200 (-> (request :post "/")
+              (assoc :session {anti-forgery-token-name ["foo"]})
+              (assoc :form-params {anti-forgery-token-name "foo"})))))
+
+(deftest multipart-form-test
+  (let [response {:status 200, :headers {}, :body "Foo"}
+        handler  (wrap-anti-forgery-session (constantly response))]
+    (is (= (-> (request :post "/")
+               (assoc :session {anti-forgery-token-name ["foo"]})
+               (assoc :multipart-params {anti-forgery-token-name "foo"})
+               handler
+               :status)
+           200))))
+
+(deftest token-in-session-test
+  (let [response {:status 200, :headers {}, :body "Foo"}
+        handler (fn [& _] (anti-forgery-token) response)
+        handler  (wrap-anti-forgery-session handler)]
+    (is (contains? (:session (handler (request :get "/")))
+                         anti-forgery-token-name))
+    (is (not= (get-in (handler (request :get "/"))
+                      [:session anti-forgery-token-name])
+              (get-in (handler (request :get "/"))
+                      [:session anti-forgery-token-name])))))
+
+(deftest token-binding-test
+  (letfn [(handler [request]
+            {:status 200
+             :headers {}
+             :body (anti-forgery-token)})]
+    (let [response ((wrap-anti-forgery-session handler) (request :get "/"))]
+      (is (= (get-in response [:session anti-forgery-token-name 0])
+             (:body response))))))
+
+(deftest nil-response
+  (letfn [(handler [request] nil)]
+    (let [response ((wrap-anti-forgery-session handler) (request :get "/"))]
+      (is (nil? response)))))
+
+(deftest no-lf-in-token-test
+  (letfn [(handler [request]
+            {:status 200
+             :headers {}
+             :body (anti-forgery-token)})]
+    (let [response ((wrap-anti-forgery-session handler) (request :get "/"))
+          token    (get-in response [:session anti-forgery-token-name 0])]
+      (is (not (.contains token "\n"))))))
+
+(deftest multiple-token-test
+  (let [handler (fn [& _] ({:status 200 :headers {} :body (anti-forgery-token)}))
+        resp (handler)
+        handler (wrap-anti-forgery-session handler 2)
+        resp1 (handler (request :get "/"))
+        #_[resp1 resp2 resp3] #_(take 3 (repeatedly (handler (request :get "/"))))]
+    (def r resp1)
+    #_(is (= (:body resp1) (get-in resp1 [:session anti-forgery-token-name 2])))))
+
+(deftest multiple-token-test
+  (let [handler (fn [req] {:status 200 :headers {} :body (when (= (:request-method req) :get) (anti-forgery-token))})
+        handler (wrap-anti-forgery-session handler 2)
+        get-request (request :get "/")
+        resp1 (handler get-request)
+        resp2 (handler (assoc get-request :session (:session resp1)))
+        resp3 (handler (assoc get-request :session (:session resp2)))]
+    (are [resp tokens] (= (get-in resp [:session anti-forgery-token-name]) tokens)
+         resp1 [nil (:body resp1)]
+         resp2 [(:body resp1) (:body resp2)]
+         resp3 [(:body resp2) (:body resp3)])
+    (are [status req] (= (:status (handler req)) status)
+         403 (-> (request :post "/")
+                 (assoc :form-params {anti-forgery-token-name (:body resp1)} :session (:session resp3)))
+         200 (-> (request :post "/")
+                 (assoc :form-params {anti-forgery-token-name (:body resp2)} :session (:session resp3)))
+         200 (-> (request :post "/")
+                 (assoc :form-params {anti-forgery-token-name (:body resp3)} :session (:session resp3))))))


### PR DESCRIPTION
Pull request allows you to store the anti-forgery token in the session instead of a cookie so you can choose whether a cookie or session is more appropriate to your situation. Also allows you to store more than one anti-forgery token (up to a specified limit which defaults to 1) so the user can have multiple forms open and submit in any order. This is actually a requirement of our users.

Pull request also addresses https://github.com/weavejester/ring-anti-forgery/issues/1 (Will not work for filling multiple form in parallel).

If this pull request is acceptable, I would be happy to add it to the readme and refactor out the common bits between anti-forgery and anti-forgery-session.
