### PR TITLE
Allow setting the token via HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following dependency to your `project.clj`:
 When a handler is wrapped in the `wrap-anti-forgery` middleware, a randomly-
 generated string is assigned to the `*anti-forgery-token*` var. This token must
 be included as a parameter named "__anti-forgery-token" for all POST requests
-to the handler.
+to the handler, or as the value of the HTTP header X-Anti-Forgery-Token.
 
 The ring-anti-forgery middleware includes a function to create a
 hidden field that you can add to your forms:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ hidden field that you can add to your forms:
 (anti-forgery-field)   ;; returns a hidden field with the anti-forgery token
 ```
 
+If you use XHR to perform requests from the client to your server, you typically
+send JSON instead of form encoded data. In this scenario, you can set a header,
+X-Anti-Forgery-Token. A common method for providing these values to your
+JavaScript is via meta tags in `<head>`, and query the DOM for these values.
+
+```clojure
+[:meta {:name "csrf_header :content "X-Anti-Forgery-Token"}]
+[:meta {:name "csrf_token" :content *anti-forgery-token*}]]
+```
+
 The forgery token is also automatically added as a session parameter
 by the middleware. If the session parameter and the POST parameter
 don't match, then a 403 Forbidden response is returned. This ensures

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -30,7 +30,8 @@
     false))
 
 (defn- valid-request? [request]
-  (let [param-token  (-> request form-params (get "__anti-forgery-token"))
+  (let [param-token  (or (-> request form-params (get "__anti-forgery-token"))
+                         (-> request :headers (get "x-anti-forgery-token")))
         stored-token (session-token request)]
     (and param-token
          stored-token

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -75,3 +75,17 @@
                                         (assoc-in [:session "foo"] "bar"))))]
     (is (contains? session "__anti-forgery-token"))
     (is (= (session "foo") "bar"))))
+
+(deftest setting-token-via-header-test
+  (let [response {:status 200, :headers {}, :body "Foo"}
+        handler  (wrap-anti-forgery (constantly response))]
+    (are [status req] (= (:status (handler req)) status)
+      403 (request :post "/")
+      403 (-> (request :post "/")
+              (assoc :headers {"x-anti-forgery-token" "foo"}))
+      403 (-> (request :post "/")
+              (assoc :session {"__anti-forgery-token" "foo"})
+              (assoc :headers {"x-anti-forgery-token" "bar"}))
+      200 (-> (request :post "/")
+              (assoc :session {"__anti-forgery-token" "foo"})
+              (assoc :headers {"x-anti-forgery-token" "foo"})))))


### PR DESCRIPTION
Quick summary: this is very useful for XHR requests where the request body is JSON instead of form encoded data.

For juicy details, see commit messages :)

Not sure if ef65f1f causes information overload, so feel very free to skip that commit.
