### PR TITLE
Token in HTTP header and more settings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-anti-forgery "0.2.1"
+(defproject ring-anti-forgery "0.3.0"
   :description "Ring middleware to prevent CSRF attacks"
   :url "https://github.com/weavejester/ring-anti-forgery"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-anti-forgery "0.3.0"
+(defproject com.bwhmather/ring-anti-forgery "0.3.0"
   :description "Ring middleware to prevent CSRF attacks"
   :url "https://github.com/weavejester/ring-anti-forgery"
   :license {:name "The MIT License"

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -21,7 +21,7 @@
 (defn get-request-token [request]
   (or (get (:form-params request) "__anti-forgery-token")
       (get (:multipart-params request) "__anti-forgery-token")
-      (get (:headers request)"anti-forgery-token")))
+      (get (:headers request)"x-anti-forgery-token")))
 
 (defn- secure-eql? [^String a ^String b]
   (if (and a b (= (.length a) (.length b)))

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -59,9 +59,9 @@
     (let [session-token (or (get-session-token request)
                              (generate-token-fn))
           request-token (get-request-token request)]
-      (if (and (post-request? request)
-               (not (valid-request? request-token session-token)))
-         (on-potential-csrf-attack request)
-         (if-let [response (binding [*anti-forgery-token* session-token]
-                             (handler request))]
-           (assoc-session-token response request session-token))))))
+      (or (and (post-request? request)
+               (not (valid-request? request-token session-token))
+               (on-potential-csrf-attack request))
+          (if-let [response (binding [*anti-forgery-token* session-token]
+                              (handler request))]
+            (assoc-session-token response request session-token))))))

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -18,12 +18,10 @@
           (assoc :session (:session request))
           (assoc-in [:session "__anti-forgery-token"] token)))))
 
-(defn- form-params [request]
-  (merge (:form-params request)
-         (:multipart-params request)))
-
 (defn get-request-token [request]
-  (-> request form-params (get "__anti-forgery-token")))
+  (or (get (:form-params request) "__anti-forgery-token")
+      (get (:multipart-params request) "__anti-forgery-token")
+      (get (:headers request)"anti-forgery-token")))
 
 (defn- secure-eql? [^String a ^String b]
   (if (and a b (= (.length a) (.length b)))

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -7,9 +7,8 @@
           in POST forms if the handler is wrapped in wrap-anti-forgery."}
   *anti-forgery-token*)
 
-(defn- session-token [request]
-  (or (get-in request [:session "__anti-forgery-token"])
-      (random/base64 60)))
+(defn- get-session-token [request]
+  (get-in request [:session "__anti-forgery-token"]))
 
 (defn- assoc-session-token [response request token]
   (let [old-token (get-in request [:session "__anti-forgery-token"])]
@@ -23,36 +22,46 @@
   (merge (:form-params request)
          (:multipart-params request)))
 
+(defn get-request-token [request]
+  (-> request form-params (get "__anti-forgery-token")))
+
 (defn- secure-eql? [^String a ^String b]
   (if (and a b (= (.length a) (.length b)))
     (zero? (reduce bit-or
                    (map bit-xor (.getBytes a) (.getBytes b))))
     false))
 
-(defn- valid-request? [request]
-  (let [param-token  (-> request form-params (get "__anti-forgery-token"))
-        stored-token (session-token request)]
-    (and param-token
-         stored-token
-         (secure-eql? param-token stored-token))))
-
-(defn- post-request? [request]
-  (= :post (:request-method request)))
+(defn- valid-request? [request-token session-token]
+  (and request-token
+       session-token
+       (secure-eql? request-token session-token)))
 
 (defn- access-denied [body]
   {:status 403
    :headers {"Content-Type" "text/html"}
    :body body})
 
+(defn invalid-csrf-token [request]
+  (access-denied "<h1>Invalid anti-forgery token</h1>"))
+
+(defn- post-request? [request]
+  (= :post (:request-method request)))
+
 (defn wrap-anti-forgery
   "Middleware that prevents CSRF attacks. Any POST request to this handler must
   contain a '__anti-forgery-token' parameter equal to the last value of the
   *anti-request-forgery* var. If the token is missing or incorrect, an access-
   denied response is returned."
-  [handler]
+  [handler & {:keys [on-potential-csrf-attack generate-token-fn]
+              :or {on-potential-csrf-attack invalid-csrf-token
+                   generate-token-fn #(random/base64 60)}}]
   (fn [request]
-    (binding [*anti-forgery-token* (session-token request)]
-      (if (and (post-request? request) (not (valid-request? request)))
-        (access-denied "<h1>Invalid anti-forgery token</h1>")
-        (if-let [response (handler request)]
-          (assoc-session-token response request *anti-forgery-token*))))))
+    (let [session-token (or (get-session-token request)
+                             (generate-token-fn))
+          request-token (get-request-token request)]
+      (if (and (post-request? request)
+               (not (valid-request? request-token session-token)))
+         (on-potential-csrf-attack request)
+         (if-let [response (binding [*anti-forgery-token* session-token]
+                             (handler request))]
+           (assoc-session-token response request session-token))))))

--- a/src/ring/util/anti_forgery.clj
+++ b/src/ring/util/anti_forgery.clj
@@ -1,5 +1,5 @@
 (ns ring.util.anti-forgery
-  (:use [hiccup core form]
+  (:use [hiccup core form def]
         ring.middleware.anti-forgery))
 
 (defn anti-forgery-field
@@ -8,3 +8,10 @@
   middleware."
   []
   (html (hidden-field "__anti-forgery-token" *anti-forgery-token*)))
+
+(defhtml anti-forgery-meta
+  "Create a pair of meta elements containing the token to allow easy access
+from javasript. Uses the rails format for compatibility."
+  []
+  [:meta {:name "csrf-param" :content "anti-forgery-token"}]
+  [:meta {:name "csrf-token" :content *anti-forgery-token*}])

--- a/src/ring/util/anti_forgery.clj
+++ b/src/ring/util/anti_forgery.clj
@@ -13,5 +13,5 @@
   "Create a pair of meta elements containing the token to allow easy access
 from javasript. Uses the rails format for compatibility."
   []
-  [:meta {:name "csrf-param" :content "anti-forgery-token"}]
+  [:meta {:name "csrf-param" :content "x-anti-forgery-token"}]
   [:meta {:name "csrf-token" :content *anti-forgery-token*}])

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -29,7 +29,7 @@
                                  :multipart-params {"__anti-forgery-token" token})))
     (request-token-type-test
       (fn [request token] (assoc request
-                                 :headers {"anti-forgery-token" token})))))
+                                 :headers {"x-anti-forgery-token" token})))))
 
 (deftest token-in-session-test
   (let [response {:status 200, :headers {}, :body "Foo"}


### PR DESCRIPTION
Merges changes from August Lilleaas and Daniel Westheide
- extra configuration options for middleware (excluded routes, token-generation callback and callbacks for invalid queries and logging)
- option to store token in request header (with documentation and tests)
- function to create html meta tags (for easier access from javascript)

Currently the history is a bit messy as the two merged branches duplicate some work.  Can rewrite to fix it but would loose authorship information.
