### PR TITLE
Making ring-anti-forgery more customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Now you need to provide a custom token extractor and maybe a custom
    :headers {"Content-Type" "application/json; charset=utf-8"}
    :body "{\"error\": \"invalid token\"}"})
 
-(def token-header-extractor [request]
+(defn token-header-extractor [request]
   (if-let [token (get-in request [:headers "x-xsrf-token"])]
     (url-decode token)))
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Now you need to provide a custom token extractor and maybe a custom
 ;; ...
 (-> handler
     (wrap-anti-forgery {:access-denied-response access-denied-response
-                        :request-token-extractor ;; token-header-extractor})
+                        :request-token-extractor token-header-extractor})
 ;; ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ring-Anti-Forgery
 
+**Warning: This fork is a shot of generalizing this library so it'll be possible
+to customize the way it handles CSRF protection. It's not yet ready!**
+
 [![Build Status](https://secure.travis-ci.org/weavejester/ring-anti-forgery.png)](http://travis-ci.org/weavejester/ring-anti-forgery)
 
 This middleware prevents [CSRF][1] attacks by providing a randomly-generated
@@ -9,7 +12,7 @@ anti-forgery token.
 
 Add the following dependency to your `project.clj`:
 
-    [ring-anti-forgery "0.2.1"]
+    [ring-anti-forgery "0.3.0-SNAPSHOT"]
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Add the following dependency to your `project.clj`:
 
 ## Usage
 
-When a handler is wrapped in the `wrap-anti-forgery` middleware, a randomly-
-generated string is assigned to the `*anti-forgery-token*` var. This token must
-be included as a parameter named "__anti-forgery-token" for all POST requests
-to the handler.
+### Default Behavior
+
+When a handler is wrapped in the `wrap-anti-forgery` middleware, a
+randomly- generated string is assigned to the `*anti-forgery-token*`
+var. This token must be included as a parameter named
+"__anti-forgery-token" for all POST/PUT/DELETE requests to the
+handler.
 
 The ring-anti-forgery middleware includes a function to create a
 hidden field that you can add to your forms:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,59 @@ by the middleware. If the session parameter and the POST parameter
 don't match, then a 403 Forbidden response is returned. This ensures
 that requests cannot be POSTed from other domains.
 
+### Customizing token passing and response
+
+Sometimes you might not want to use the default "__anti-forgery-token"
+form parameter or you may want to customize the *access denied*
+response. Here's an example for working with [AngularJS][2].
+
+AngularJS uses a [different mechanism for working with csrf][3]. It
+gets the token from the server via a cookie named *XSRF-TOKEN* and it
+adds the token to all *post* requests via the *x-xsrf-token* header.
+Here's how to use it.
+
+A wrapper to add the required cookie. You can use it to wrap your
+*home* page response:
+
+```clojure
+(ns some.ns
+  (:use ring.middleware.anti-forgery
+        [ring.util.codec :only (url-decode)]))
+
+;; ...
+
+(defn anti-forgery-cookie
+  "wraps a response with"
+  [response]
+  (-> response
+      (assoc-in [:cookies "XSRF-TOKEN" :value] *anti-forgery-token*)))
+
+;; ...
+```
+Now you need to provide a custom token extractor and maybe a custom
+*access denied* json response:
+
+```clojure
+;; ...
+
+(def access-denied-response
+  {:status 403,
+   :headers {"Content-Type" "application/json; charset=utf-8"}
+   :body "{\"error\": \"invalid token\"}"})
+
+(def token-header-extractor [request]
+  (if-let [token (get-in request [:headers "x-xsrf-token"])]
+    (url-decode token)))
+
+;; now call wrap-anti-forgery with options:
+;; ...
+(-> handler
+    (wrap-anti-forgery {:access-denied-response access-denied-response
+                        :request-token-extractor ;; token-header-extractor})
+;; ...
+```
+
+
 ## Caveats
 
 The anti-forgery middleware will prevent POSTs working for web service routes,
@@ -42,6 +95,8 @@ so you should only apply this middleware to the part of your website meant
 for browsers.
 
 [1]: http://en.wikipedia.org/wiki/Cross-site_request_forgery
+[2]: http://angularjs.org
+[3]: http://docs.angularjs.org/api/ng.$http
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-anti-forgery "0.2.1"
+(defproject ring-anti-forgery "0.3.0-SNAPSHOT"
   :description "Ring middleware to prevent CSRF attacks"
   :url "https://github.com/weavejester/ring-anti-forgery"
   :license {:name "The MIT License"

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -43,8 +43,8 @@
          stored-token
          (secure-eql? request-token stored-token))))
 
-(defn- post-request? [request]
-  (= :post (:request-method request)))
+(defn- require-protection? [request]
+  (some (hash-set (:request-method request)) [:post :put :delete]))
 
 (defn access-denied-response
   "Produces an access-denied response with text/html content type, 403 status
@@ -85,7 +85,7 @@
      (let [opts (merge defaults options)]
        (fn [request]
          (binding [*anti-forgery-token* (session-token request)]
-           (if (and (post-request? request)
+           (if (and (require-protection? request)
                     (not (valid-request? request (:request-token-extractor opts))))
              (:access-denied-response opts)
              (if-let [response (handler request)]

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -29,12 +29,19 @@
                    (map bit-xor (.getBytes a) (.getBytes b))))
     false))
 
-(defn- valid-request? [request]
-  (let [param-token  (-> request form-params (get "__anti-forgery-token"))
+(defn- extract-request-token [request]
+  (-> request form-params (get "__anti-forgery-token")))
+
+(defn- valid-request?
+  "Indicates whether the supplied request has a valid token.
+  The `extractor` is a function that accepts the request and
+  extracts the token from it."
+  [request extractor]
+  (let [request-token (extractor request)
         stored-token (session-token request)]
-    (and param-token
+    (and request-token
          stored-token
-         (secure-eql? param-token stored-token))))
+         (secure-eql? request-token stored-token))))
 
 (defn- post-request? [request]
   (= :post (:request-method request)))
@@ -53,7 +60,8 @@
 (def ^:private
   ^{:doc "defaults for wrap-anti-forgery"}
   defaults {:access-denied-response (access-denied-response
-                                     "<h1>Invalid anti-forgery token</h1>")})
+                                     "<h1>Invalid anti-forgery token</h1>")
+            :request-token-extractor extract-request-token})
 
 (defn wrap-anti-forgery
   "Middleware that prevents CSRF attacks. Any POST request to this handler must
@@ -65,13 +73,20 @@
   this middleware:
     :access-denied-response
       A custom ring response (map) such as produced by (access-denied-response).
-      This response *should* have a status of 403."
+      This response *should* have a status of 403.
+    :request-token-extractor 
+      In some cases you might want to pass the token not via the
+      default request parameters but by other means (e.g. AngularJS
+      passes the csrf token as a header). In this case you may supply
+      a function that extracts the token from the request (or return
+      nil of the token doesn't exist)."
   ([handler] (wrap-anti-forgery handler {}))
   ([handler options]
      (let [opts (merge defaults options)]
        (fn [request]
          (binding [*anti-forgery-token* (session-token request)]
-           (if (and (post-request? request) (not (valid-request? request)))
+           (if (and (post-request? request)
+                    (not (valid-request? request (:request-token-extractor opts))))
              (:access-denied-response opts)
              (if-let [response (handler request)]
                (assoc-session-token response request *anti-forgery-token*))))))))

--- a/src/ring/middleware/anti_forgery.clj
+++ b/src/ring/middleware/anti_forgery.clj
@@ -39,20 +39,39 @@
 (defn- post-request? [request]
   (= :post (:request-method request)))
 
-(defn- access-denied [body]
+(defn access-denied-response
+  "Produces an access-denied response with text/html content type, 403 status
+  and the supplied body.
+
+  The resulted response could be used to customize the access denied response
+  in the wrap-anti-forgery middleware."
+  [body]
   {:status 403
    :headers {"Content-Type" "text/html"}
    :body body})
+
+(def ^:private
+  ^{:doc "defaults for wrap-anti-forgery"}
+  defaults {:access-denied-response (access-denied-response
+                                     "<h1>Invalid anti-forgery token</h1>")})
 
 (defn wrap-anti-forgery
   "Middleware that prevents CSRF attacks. Any POST request to this handler must
   contain a '__anti-forgery-token' parameter equal to the last value of the
   *anti-request-forgery* var. If the token is missing or incorrect, an access-
-  denied response is returned."
-  [handler]
-  (fn [request]
-    (binding [*anti-forgery-token* (session-token request)]
-      (if (and (post-request? request) (not (valid-request? request)))
-        (access-denied "<h1>Invalid anti-forgery token</h1>")
-        (if-let [response (handler request)]
-          (assoc-session-token response request *anti-forgery-token*))))))
+  denied response is returned.
+
+  The following options are available to customize the behavior of
+  this middleware:
+    :access-denied-response
+      A custom ring response (map) such as produced by (access-denied-response).
+      This response *should* have a status of 403."
+  ([handler] (wrap-anti-forgery handler {}))
+  ([handler options]
+     (let [opts (merge defaults options)]
+       (fn [request]
+         (binding [*anti-forgery-token* (session-token request)]
+           (if (and (post-request? request) (not (valid-request? request)))
+             (:access-denied-response opts)
+             (if-let [response (handler request)]
+               (assoc-session-token response request *anti-forgery-token*))))))))

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -75,3 +75,19 @@
                                         (assoc-in [:session "foo"] "bar"))))]
     (is (contains? session "__anti-forgery-token"))
     (is (= (session "foo") "bar"))))
+
+(deftest access-denied-response-test
+  (let [response (access-denied-response "some body")]
+    (is (= (:status response) 403) "default status")
+    (is (= (:body response) "some body"))))
+
+(deftest wrap-anti-forgery-access-denied-response-test
+  (testing "default response"
+    (let [handler (wrap-anti-forgery (constantly "some response"))
+          expected (access-denied-response "<h1>Invalid anti-forgery token</h1>")]
+      (is (= (handler (request :post "/")) expected))))
+  (testing "custom response"
+    (let [expected-response (access-denied-response "custom body")
+          handler (wrap-anti-forgery (constantly "some response")
+                                     {:access-denied-response expected-response})]
+      (is (= (handler (request :post "/")) expected-response)))))

--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -17,6 +17,15 @@
               (assoc :session {"__anti-forgery-token" "foo"})
               (assoc :form-params {"__anti-forgery-token" "foo"})))))
 
+(deftest methods-that-require-protection
+  (let [response {:status 200, :headers {}, :body "Foo"}
+        handler (wrap-anti-forgery (constantly response))]
+    (are [status req] (= (:status (handler req)) status)
+         403 (request :post "/")
+         403 (request :put "/")
+         403 (request :delete "/")
+         200 (request :get "/"))))
+
 (deftest multipart-form-test
   (let [response {:status 200, :headers {}, :body "Foo"}
         handler  (wrap-anti-forgery (constantly response))]


### PR DESCRIPTION
Hi

This is my shot at making ring-anti-forgery more customizable. The only default behavior I changed is that the wrapper checks PUT/DELETE requests as well as POST requests.

The following customizations are offered:
- A custom response (so it's possible to return a json response or nicer html).
- An alternative function to extract the token from the request (e.g. AngularJS uses a different method to handle tokens - it adds them to the request headers).

I don't know much about clojure and I know even less about security. I did my best at figuring out what the code is doing and I changed as little as I could to add these customizations. I hope I didn't introduce some security issue.

There is a small project I'm writing to learn clojure that is using this fork. It's available [here](http://github.com/babysnakes/ayler).

One last thing, If you accept this pull request you need to remove the note at the beginning of the readme file :smile: 

Thanks in advance

Haim
