### PR TITLE
Add anti-forgery-meta-tags helper to util namespace

### DIFF
--- a/src/ring/util/anti_forgery.clj
+++ b/src/ring/util/anti_forgery.clj
@@ -1,5 +1,5 @@
 (ns ring.util.anti-forgery
-  (:use [hiccup core form]
+  (:use [hiccup core form element]
         ring.middleware.anti-forgery))
 
 (defn anti-forgery-field
@@ -8,3 +8,10 @@
   middleware."
   []
   (html (hidden-field "__anti-forgery-token" *anti-forgery-token*)))
+
+(defn script-token
+  "Generate a script tag defining the token as the given variable name in
+  JavaScript or use the default, \"CSRF_TOKEN\"."
+  [& [var-name]]
+  (html (javascript-tag
+          (str (or var-name "CSRF_TOKEN") " = \"" *anti-forgery-token* "\";"))))

--- a/test/ring/util/test/anti_forgery.clj
+++ b/test/ring/util/test/anti_forgery.clj
@@ -8,3 +8,12 @@
     (is (= (anti-forgery-field)
            (str "<input id=\"__anti-forgery-token\" name=\"__anti-forgery-token\""
                 " type=\"hidden\" value=\"abc\" />")))))
+
+(deftest script-token-test
+  (binding [*anti-forgery-token* "abc"]
+    (is (= (script-token)
+           (str "<script type=\"text/javascript\">//<![CDATA[\n"
+                "CSRF_TOKEN = \"abc\";\n//]]></script>")))
+    (is (= (script-token "otherName")
+           (str "<script type=\"text/javascript\">//<![CDATA[\n"
+                "otherName = \"abc\";\n//]]></script>")))))


### PR DESCRIPTION
Meta tags are helpful for setting request headers via JavaScript. I use this helper and I thought others might like it too.
