### PR TITLE
Allow error-response to be a handler fn

### DIFF
--- a/test/ring/middleware/test/anti_forgery.clj
+++ b/test/ring/middleware/test/anti_forgery.clj
@@ -97,13 +97,30 @@
 
 (deftest custom-error-response-test
   (let [response   {:status 200, :headers {}, :body "Foo"}
-        error-resp {:statis 500, :headers {}, :body "Bar"}
+        error-resp {:status 500, :headers {}, :body "Bar"}
         handler    (wrap-anti-forgery (constantly response)
                                       {:error-response error-resp})]
     (is (= (dissoc (handler (request :get "/")) :session)
            response))
     (is (= (dissoc (handler (request :post "/")) :session)
            error-resp))))
+
+(deftest custom-error-handler-test
+  (let [response   {:status 200, :headers {}, :body "Foo"}
+        error-resp {:status 500, :headers {}, :body "Bar"}
+        handler    (wrap-anti-forgery (constantly response)
+                                      {:error-handler (fn [request] error-resp)})]
+    (is (= (dissoc (handler (request :get "/")) :session)
+           response))
+    (is (= (dissoc (handler (request :post "/")) :session)
+           error-resp))))
+
+(deftest disallow-both-error-response-and-error-handler
+  (is (thrown?
+        AssertionError
+        (wrap-anti-forgery (constantly {:status 200})
+                           {:error-handler (fn [request] {:status 500 :body "Handler"})
+                            :error-response {:status 500 :body "Response"}}))))
 
 (deftest custom-read-token-test
   (let [response {:status 200, :headers {}, :body "Foo"}


### PR DESCRIPTION
This is useful whenever you want the error response to depend on the request. In my case, I just need it because I have a whole asset pipeline thing set up through middleware, but I can easily imagine scenarios where I'd want to produce an error page that includes personalized / session-based stuff, just with an error message. It's a small enough tweak that I don't see much risk to this patch, but I'll let you be the judge of that. :smile:
